### PR TITLE
Update/fix native class creation.

### DIFF
--- a/addon/-private/modifier-manager.js
+++ b/addon/-private/modifier-manager.js
@@ -12,10 +12,14 @@ export default class ModifierManager {
   }
 
   createModifier(Klass, args) {
-    let isEmberObject = Klass.create !== undefined;
-    return isEmberObject
-      ? Klass.create(this.owner.ownerInjection(), args.named)
-      : new Klass(args.named, this.owner);
+    let isEmberObject = Klass.class.create !== undefined;
+
+    if (isEmberObject) {
+      return Klass.create(args.named);
+    } else {
+      let Constructor = Klass.class;
+      return new Constructor(args.named, this.owner);
+    }
   }
 
   installModifier(instance, element, args) {


### PR DESCRIPTION
The first argument passed to `createModifier` is the _result_ of calling `owner.factoryFor` and **will always** have a `.create` method on it. This tweaks the logic of `.createModifier` to look at `klass.class` (LOL, I know I know) instead (since `klass.class` represents the _actual_ export from the module).