### PR TITLE
Remove the need to call modifier on exported modifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ const ScrollTopModifier = Modifier.extend({
   }
 });
 
-export default Modifier.modifier(ScrollTopModifier);
+export default ScrollTopModifier;
 ```
 
 Then, use it in your template:
@@ -71,13 +71,11 @@ Then, use it in your template:
 // app/modifiers/scroll-top.js
 import Modifier from 'ember-oo-modifiers';
 
-class ScrollTopModifier extends Modifier {
+export default class ScrollTopModifier extends Modifier {
   didReceiveArguments([scrollPosition]) {
     this.element.scrollTop = scrollPosition;
   }
 }
-
-export default Modifier.modifier(ScrollTopModifier);
 ```
 
 Then, use it in your template:
@@ -120,7 +118,7 @@ const MoveRandomlyModifier = Modifier.extend({
   }
 });
 
-export default Modifier.modifier(MoveRandomlyModifier);
+export default MoveRandomlyModifier;
 ```
 
 ```hbs
@@ -138,7 +136,7 @@ import Modifier from 'ember-oo-modifiers';
 const { random, round } = Math;
 const INTERVAL_DELAY = 1000;
 
-class MoveRandomlyModifier extends Modifier {
+export default class MoveRandomlyModifier extends Modifier {
   updateTransform() {
     let top = round(random() * 500);
     let left = round(random() * 500);
@@ -154,8 +152,6 @@ class MoveRandomlyModifier extends Modifier {
     this.timer = null;
   }
 }
-
-export default Modifier.modifier(MoveRandomlyModifier);
 ```
 
 ```hbs
@@ -191,7 +187,7 @@ const TrackClickModifier = Modifier.extend({
   }
 });
 
-export default Modifier.modifier(TrackClickModifier);
+export default TrackClickModifier;
 ```
 
 Then, you could use this in your template:
@@ -209,7 +205,7 @@ Then, you could use this in your template:
 import { inject as service } from '@ember-decorators/service';
 import Modifier from 'ember-oo-modifiers';
 
-class TrackClickModifier extends Modifier {
+export default class TrackClickModifier extends Modifier {
   @service metrics
 
   didInsertElement([eventName], options) {
@@ -222,8 +218,6 @@ class TrackClickModifier extends Modifier {
     this.trackingCallback = null;
   }
 }
-
-export default Modifier.modifier(TrackClickModifier);
 ```
 
 Then, you could use this in your template:
@@ -259,7 +253,7 @@ import { Modifier } from 'ember-oo-modifiers';
 const MyModifier = Modifier.extend({
 });
 
-export default Modifier.modifier(MyModifier);
+export default MyModifier;
 ```
 
 #### Native Class Import
@@ -267,10 +261,8 @@ export default Modifier.modifier(MyModifier);
 ```js
 import Modifier from 'ember-oo-modifiers';
 
-class MyModifier extends Modifier {
+export default class MyModifier extends Modifier {
 }
-
-export default Modifier.modifier(MyModifier);
 ```
 
 Contributing

--- a/addon/-private/modifier-classic.js
+++ b/addon/-private/modifier-classic.js
@@ -1,6 +1,7 @@
 import Ember from 'ember';
 import EmberObject from '@ember/object';
 import createManager from './create-manager';
+import  { deprecate } from '@ember/application/deprecations';
 
 const Modifier = EmberObject.extend({
   element: null,
@@ -12,8 +13,11 @@ const Modifier = EmberObject.extend({
 
 Modifier.reopenClass({
   modifier(Klass) {
-    return Ember._setModifierManager(createManager, Klass);
+    deprecate("Modifier.modifier is deprecated.  Export the class directly.  See https://github.com/sukima/ember-oo-modifiers/pull/8", false, { id: 'modifier-call', until: "1.0.0" });
+    return Klass;
   }
 });
+
+Ember._setModifierManager(createManager, Modifier);
 
 export default Modifier;

--- a/addon/-private/modifier-native.js
+++ b/addon/-private/modifier-native.js
@@ -2,8 +2,9 @@ import Ember from 'ember';
 import { setOwner } from '@ember/application';
 import { setProperties } from '@ember/object';
 import createManager from './create-manager';
+import  { deprecate } from '@ember/application/deprecations';
 
-export default class Modifier {
+class Modifier {
   constructor(attrs = {}, _owner) {
     setOwner(this, _owner);
     setProperties(this, attrs);
@@ -15,6 +16,11 @@ export default class Modifier {
   willDestroyElement() {}
 
   static modifier(Klass) {
-    return Ember._setModifierManager(createManager, Klass);
+    deprecate("Modifier.modifier is deprecated.  Export the class directly.  See https://github.com/sukima/ember-oo-modifiers/pull/8", false, { id: 'modifier-call', until: "1.0.0" });
+    return Klass;
   }
 }
+
+Ember._setModifierManager(createManager, Modifier);
+
+export default Modifier;

--- a/tests/integration/modifier-managers/oo-modifiers-classic-test.js
+++ b/tests/integration/modifier-managers/oo-modifiers-classic-test.js
@@ -13,11 +13,55 @@ module('Integration | Modifier Manager | oo modifier (classic)', function(hooks)
       this.owner.register(`modifier:${name}`, modifier);
     };
     this.registerModifierClass = (name, ModifierClass) => {
-      this.registerModifier(name, Modifier.modifier(ModifierClass));
+      this.registerModifier(name, ModifierClass);
     };
   });
 
-  module('didInsertElement', function() {
+  module('didInsertElement with calling deprecated Modifier.modifier', function() {
+    test('it has DOM element on this.element', async function(assert) {
+      this.registerModifierClass(
+        'songbird',
+        Modifier.modifier(
+          Modifier.extend({
+            didInsertElement() { assert.equal(this.element.tagName, 'H1'); }
+          })
+        )
+      );
+      await render(hbs`<h1 {{songbird}}>Hello</h1>`);
+    });
+
+    test('positional arguments are passed', async function(assert) {
+      this.registerModifierClass(
+        'songbird',
+        Modifier.modifier(
+          Modifier.extend({
+            didInsertElement([a, b]) {
+              assert.equal(a, '1');
+              assert.equal(b, '2');
+            }
+          })
+        )
+      );
+      await render(hbs`<h1 {{songbird "1" "2"}}>Hey</h1>`);
+    });
+
+    test('named arguments are passed', async function(assert) {
+      this.registerModifierClass(
+        'songbird',
+        Modifier.modifier(
+          Modifier.extend({
+            didInsertElement(_, { a, b }) {
+              assert.equal(a, '1');
+              assert.equal(b, '2');
+            }
+          })
+        )
+      );
+      await render(hbs`<h1 {{songbird a="1" b="2"}}>Hey</h1>`);
+    });
+  });
+
+  module('didInsertElement without calling Modifier.modifier', function() {
     test('it has DOM element on this.element', async function(assert) {
       this.registerModifierClass(
         'songbird',
@@ -54,8 +98,52 @@ module('Integration | Modifier Manager | oo modifier (classic)', function(hooks)
       await render(hbs`<h1 {{songbird a="1" b="2"}}>Hey</h1>`);
     });
   });
+  
+  module('didRecieveArguments with calling deprecated Modifier.modifier', function() {
+    test('it has DOM element on this.element', async function(assert) {
+      this.registerModifierClass(
+        'songbird',
+        Modifier.modifier(
+          Modifier.extend({
+            didReceiveArguments() { assert.equal(this.element.tagName, 'H1'); }
+          })
+        )
+      );
+      await render(hbs`<h1 {{songbird}}>Hello</h1>`);
+    });
 
-  module('didRecieveArguments', function() {
+    test('positional arguments are passed', async function(assert) {
+      this.registerModifierClass(
+        'songbird',
+        Modifier.modifier(
+          Modifier.extend({
+            didReceiveArguments([a, b]) {
+              assert.equal(a, '1');
+              assert.equal(b, '2');
+            }
+          })
+        )
+      );
+      await render(hbs`<h1 {{songbird "1" "2"}}>Hey</h1>`);
+    });
+
+    test('named arguments are passed', async function(assert) {
+      this.registerModifierClass(
+        'songbird',
+        Modifier.modifier(
+          Modifier.extend({
+            didReceiveArguments(_, { a, b }) {
+              assert.equal(a, '1');
+              assert.equal(b, '2');
+            }
+          })
+        )
+      );
+      await render(hbs`<h1 {{songbird a="1" b="2"}}>Hey</h1>`);
+    });
+  });
+
+  module('didRecieveArguments without calling Modifier.modifier', function() {
     test('it has DOM element on this.element', async function(assert) {
       this.registerModifierClass(
         'songbird',
@@ -93,7 +181,57 @@ module('Integration | Modifier Manager | oo modifier (classic)', function(hooks)
     });
   });
 
-  module('didUpdateArguments', function() {
+  module('didUpdateArguments with calling deprecated Modifier.modifier', function() {
+    test('it has DOM element on this.element', async function(assert) {
+      this.value = 0;
+      this.registerModifierClass(
+        'songbird',
+        Modifier.modifier(
+          Modifier.extend({
+            didUpdateArguments() { assert.equal(this.element.tagName, 'H1'); }
+          })
+        )
+      );
+      await render(hbs`<h1 {{songbird this.value}}>Hello</h1>`);
+      this.set('value', 1);
+    });
+
+    test('positional arguments are passed', async function(assert) {
+      this.value = 0;
+      this.registerModifierClass(
+        'songbird',
+        Modifier.modifier(
+          Modifier.extend({
+            didUpdateArguments([, a, b]) {
+              assert.equal(a, '1');
+              assert.equal(b, '2');
+            }
+          })
+        )
+      );
+      await render(hbs`<h1 {{songbird this.value "1" "2"}}>Hey</h1>`);
+      this.set('value', 1);
+    });
+
+    test('named arguments are passed', async function(assert) {
+      this.value = 0;
+      this.registerModifierClass(
+        'songbird',
+        Modifier.modifier(
+          Modifier.extend({
+            didUpdateArguments(_, { a, b }) {
+              assert.equal(a, '1');
+              assert.equal(b, '2');
+            }
+          })
+        )
+      );
+      await render(hbs`<h1 {{songbird this.value a="1" b="2"}}>Hey</h1>`);
+      this.set('value', 1);
+    });
+  });
+
+  module('didUpdateArguments without calling Modifier.modifier', function() {
     test('it has DOM element on this.element', async function(assert) {
       this.value = 0;
       this.registerModifierClass(
@@ -137,7 +275,69 @@ module('Integration | Modifier Manager | oo modifier (classic)', function(hooks)
     });
   });
 
-  module('willDestroyElement', function() {
+  module('willDestroyElement with calling deprecated Modifier.modifier', function() {
+    test('it has DOM element on this.element', async function(assert) {
+      this.shouldRender = true;
+      this.registerModifierClass(
+        'songbird',
+        Modifier.modifier(
+          Modifier.extend({
+            willDestroyElement() { assert.equal(this.element.tagName, 'H1'); }
+          })
+        )
+      );
+      await render(hbs`
+        {{#if this.shouldRender}}
+          <h1 {{songbird}}>Hello</h1>
+        {{/if}}
+      `);
+      this.set('shouldRender', false);
+    });
+
+    test('positional arguments are passed', async function(assert) {
+      this.shouldRender = true;
+      this.registerModifierClass(
+        'songbird',
+        Modifier.modifier(
+          Modifier.extend({
+            willDestroyElement([a, b]) {
+              assert.equal(a, '1');
+              assert.equal(b, '2');
+            }
+          })
+        )
+      );
+      await render(hbs`
+        {{#if this.shouldRender}}
+          <h1 {{songbird "1" "2"}}>Hey</h1>
+        {{/if}}
+      `);
+      this.set('shouldRender', false);
+    });
+
+    test('named arguments are passed', async function(assert) {
+      this.shouldRender = true;
+      this.registerModifierClass(
+        'songbird',
+        Modifier.modifier(
+          Modifier.extend({
+            willDestroyElement(_, { a, b }) {
+              assert.equal(a, '1');
+              assert.equal(b, '2');
+            }
+          })
+        )
+      );
+      await render(hbs`
+        {{#if this.shouldRender}}
+          <h1 {{songbird a="1" b="2"}}>Hey</h1>
+        {{/if}}
+      `);
+      this.set('shouldRender', false);
+    });
+  });
+
+  module('willDestroyElement without calling Modifier.modifier', function() {
     test('it has DOM element on this.element', async function(assert) {
       this.shouldRender = true;
       this.registerModifierClass(
@@ -193,51 +393,107 @@ module('Integration | Modifier Manager | oo modifier (classic)', function(hooks)
     });
   });
 
-  test('has correct lifecycle hooks ordering', async function(assert) {
-    let callstack = [];
-    this.value = 0;
-    this.shouldRender = true;
-    this.registerModifierClass(
-      'songbird',
-      Modifier.extend({
-        didInsertElement() { callstack.push('didInsertElement'); },
-        didReceiveArguments() { callstack.push('didReceiveArguments'); },
-        didUpdateArguments() { callstack.push('didUpdateArguments'); },
-        willDestroyElement() { callstack.push('willDestroyElement'); }
-      })
-    );
-    await render(hbs`
+  module('Lifecycle and dependency with calling deprecated Modifier.modifier', function() {
+    test('has correct lifecycle hooks ordering', async function(assert) {
+      let callstack = [];
+      this.value = 0;
+      this.shouldRender = true;
+      this.registerModifierClass(
+        'songbird',
+        Modifier.modifier(
+          Modifier.extend({
+            didInsertElement() { callstack.push('didInsertElement'); },
+            didReceiveArguments() { callstack.push('didReceiveArguments'); },
+            didUpdateArguments() { callstack.push('didUpdateArguments'); },
+            willDestroyElement() { callstack.push('willDestroyElement'); }
+          })
+        )
+      );
+      await render(hbs`
       {{#if this.shouldRender}}
         <h1 {{songbird this.value}}>Hey</h1>
       {{/if}}
     `);
-    this.set('value', 1);
-    await settled();
-    this.set('shouldRender', false);
-    await settled();
-    assert.deepEqual(callstack, [
-      'didInsertElement',
-      'didReceiveArguments',
-      'didReceiveArguments',
-      'didUpdateArguments',
-      'willDestroyElement'
-    ]);
+      this.set('value', 1);
+      await settled();
+      this.set('shouldRender', false);
+      await settled();
+      assert.deepEqual(callstack, [
+        'didInsertElement',
+        'didReceiveArguments',
+        'didReceiveArguments',
+        'didUpdateArguments',
+        'willDestroyElement'
+      ]);
+    });
+
+    test('can participate in ember dependency injection', async function(assert) {
+      this.owner.register(
+        'service:test-service',
+        Service.extend({ value: 'test-service-value' })
+      );
+      this.registerModifierClass(
+        'songbird',
+        Modifier.modifier(
+          Modifier.extend({
+            testService: service(),
+            didInsertElement() {
+              assert.equal(this.testService.value, 'test-service-value');
+            }
+          })
+        )
+      );
+      await render(hbs`<h1 {{songbird}}>Hello</h1>`);
+    });
   });
 
-  test('can participate in ember dependency injection', async function(assert) {
-    this.owner.register(
-      'service:test-service',
-      Service.extend({ value: 'test-service-value' })
-    );
-    this.registerModifierClass(
-      'songbird',
-      Modifier.extend({
-        testService: service(),
-        didInsertElement() {
-          assert.equal(this.testService.value, 'test-service-value');
-        }
-      })
-    );
-    await render(hbs`<h1 {{songbird}}>Hello</h1>`);
+  module('Lifecycle and dependency without calling Modifier.modifier', function() {
+    test('has correct lifecycle hooks ordering', async function(assert) {
+      let callstack = [];
+      this.value = 0;
+      this.shouldRender = true;
+      this.registerModifierClass(
+        'songbird',
+        Modifier.extend({
+          didInsertElement() { callstack.push('didInsertElement'); },
+          didReceiveArguments() { callstack.push('didReceiveArguments'); },
+          didUpdateArguments() { callstack.push('didUpdateArguments'); },
+          willDestroyElement() { callstack.push('willDestroyElement'); }
+        })
+      );
+      await render(hbs`
+      {{#if this.shouldRender}}
+        <h1 {{songbird this.value}}>Hey</h1>
+      {{/if}}
+    `);
+      this.set('value', 1);
+      await settled();
+      this.set('shouldRender', false);
+      await settled();
+      assert.deepEqual(callstack, [
+        'didInsertElement',
+        'didReceiveArguments',
+        'didReceiveArguments',
+        'didUpdateArguments',
+        'willDestroyElement'
+      ]);
+    });
+
+    test('can participate in ember dependency injection', async function(assert) {
+      this.owner.register(
+        'service:test-service',
+        Service.extend({ value: 'test-service-value' })
+      );
+      this.registerModifierClass(
+        'songbird',
+        Modifier.extend({
+          testService: service(),
+          didInsertElement() {
+            assert.equal(this.testService.value, 'test-service-value');
+          }
+        })
+      );
+      await render(hbs`<h1 {{songbird}}>Hello</h1>`);
+    });
   });
 });

--- a/tests/integration/modifier-managers/oo-modifiers-native-test.js
+++ b/tests/integration/modifier-managers/oo-modifiers-native-test.js
@@ -14,11 +14,52 @@ module('Integration | Modifier Manager | oo modifier (native)', function(hooks) 
       this.owner.register(`modifier:${name}`, modifier);
     };
     this.registerModifierClass = (name, ModifierClass) => {
-      this.registerModifier(name, Modifier.modifier(ModifierClass));
+      this.registerModifier(name, ModifierClass);
     };
   });
 
-  module('didInsertElement', function() {
+  module('didInsertElement with calling deprecated Modifier.modfier', function() {
+    test('it has DOM element on this.element', async function(assert) {
+      class SongbirdModifier extends Modifier {
+        didInsertElement() { assert.equal(this.element.tagName, 'H1'); }
+      }
+      this.registerModifierClass(
+        'songbird',
+        Modifier.modifier(SongbirdModifier)
+      );
+      await render(hbs`<h1 {{songbird}}>Hello</h1>`);
+    });
+
+    test('positional arguments are passed', async function(assert) {
+      class SongbirdModifier extends Modifier {
+        didInsertElement([a, b]) {
+          assert.equal(a, '1');
+          assert.equal(b, '2');
+        }
+      }
+      this.registerModifierClass(
+        'songbird',
+        Modifier.modifier(SongbirdModifier)
+      );
+      await render(hbs`<h1 {{songbird "1" "2"}}>Hey</h1>`);
+    });
+
+    test('named arguments are passed', async function(assert) {
+      class SongbirdModifier extends Modifier {
+        didInsertElement(_, { a, b }) {
+          assert.equal(a, '1');
+          assert.equal(b, '2');
+        }
+      }
+      this.registerModifierClass(
+        'songbird',
+        Modifier.modifier(SongbirdModifier)
+      );
+      await render(hbs`<h1 {{songbird a="1" b="2"}}>Hey</h1>`);
+    });
+  });
+
+  module('didInsertElement without calling Modifier.modifier', function() {
     test('it has DOM element on this.element', async function(assert) {
       this.registerModifierClass(
         'songbird',
@@ -56,7 +97,48 @@ module('Integration | Modifier Manager | oo modifier (native)', function(hooks) 
     });
   });
 
-  module('didRecieveArguments', function() {
+  module('didRecieveArguments with calling deprecated Modifier.modifier', function() {
+    test('it has DOM element on this.element', async function(assert) {
+      class SongbirdModifier extends Modifier {
+        didReceiveArguments() { assert.equal(this.element.tagName, 'H1'); }
+      }
+      this.registerModifierClass(
+        'songbird',
+        Modifier.modifier(SongbirdModifier)
+      );
+      await render(hbs`<h1 {{songbird}}>Hello</h1>`);
+    });
+
+    test('positional arguments are passed', async function(assert) {
+      class SongbirdModifier extends Modifier {
+        didReceiveArguments([a, b]) {
+          assert.equal(a, '1');
+          assert.equal(b, '2');
+        }
+      }
+      this.registerModifierClass(
+        'songbird',
+        Modifier.modifier(SongbirdModifier)
+      );
+      await render(hbs`<h1 {{songbird "1" "2"}}>Hey</h1>`);
+    });
+
+    test('named arguments are passed', async function(assert) {
+      class SongbirdModifier extends Modifier {
+        didReceiveArguments(_, { a, b }) {
+          assert.equal(a, '1');
+          assert.equal(b, '2');
+        }
+      }
+      this.registerModifierClass(
+        'songbird',
+        Modifier.modifier(SongbirdModifier)
+      );
+      await render(hbs`<h1 {{songbird a="1" b="2"}}>Hey</h1>`);
+    });
+  });
+
+  module('didRecieveArguments without calling Modifier.modifier', function() {
     test('it has DOM element on this.element', async function(assert) {
       this.registerModifierClass(
         'songbird',
@@ -93,8 +175,55 @@ module('Integration | Modifier Manager | oo modifier (native)', function(hooks) 
       await render(hbs`<h1 {{songbird a="1" b="2"}}>Hey</h1>`);
     });
   });
+  
+  module('didUpdateArguments with calling deprecated Modifier.modifier', function() {
+    test('it has DOM element on this.element', async function(assert) {
+      this.value = 0;
+      class SongbirdModifier extends Modifier {
+        didUpdateArguments() { assert.equal(this.element.tagName, 'H1'); }
+      }
+      this.registerModifierClass(
+        'songbird',
+        Modifier.modifier(SongbirdModifier)
+      );
+      await render(hbs`<h1 {{songbird this.value}}>Hello</h1>`);
+      this.set('value', 1);
+    });
 
-  module('didUpdateArguments', function() {
+    test('positional arguments are passed', async function(assert) {
+      this.value = 0;
+      class SongbirdModifier extends Modifier {
+        didUpdateArguments([, a, b]) {
+          assert.equal(a, '1');
+          assert.equal(b, '2');
+        }
+      }
+      this.registerModifierClass(
+        'songbird',
+        Modifier.modifier(SongbirdModifier)
+      );
+      await render(hbs`<h1 {{songbird this.value "1" "2"}}>Hey</h1>`);
+      this.set('value', 1);
+    });
+
+    test('named arguments are passed', async function(assert) {
+      this.value = 0;
+      class SongbirdModifier extends Modifier {
+        didUpdateArguments(_, { a, b }) {
+          assert.equal(a, '1');
+          assert.equal(b, '2');
+        }
+      }
+      this.registerModifierClass(
+        'songbird',
+        Modifier.modifier(SongbirdModifier)
+      );
+      await render(hbs`<h1 {{songbird this.value a="1" b="2"}}>Hey</h1>`);
+      this.set('value', 1);
+    });
+  });
+
+  module('didUpdateArguments without calling Modifier.modifier', function() {
     test('it has DOM element on this.element', async function(assert) {
       this.value = 0;
       this.registerModifierClass(
@@ -138,7 +267,66 @@ module('Integration | Modifier Manager | oo modifier (native)', function(hooks) 
     });
   });
 
-  module('willDestroyElement', function() {
+  module('willDestroyElement with calling deprecated Modifier.modifier', function() {
+    test('it has DOM element on this.element', async function(assert) {
+      this.shouldRender = true;
+      class SongbirdModifier extends Modifier {
+        willDestroyElement() { assert.equal(this.element.tagName, 'H1'); }
+      }
+      this.registerModifierClass(
+        'songbird',
+        Modifier.modifier(SongbirdModifier)
+      );
+      await render(hbs`
+        {{#if this.shouldRender}}
+          <h1 {{songbird}}>Hello</h1>
+        {{/if}}
+      `);
+      this.set('shouldRender', false);
+    });
+
+    test('positional arguments are passed', async function(assert) {
+      this.shouldRender = true;
+      class SongbirdModifier extends Modifier {
+        willDestroyElement([a, b]) {
+          assert.equal(a, '1');
+          assert.equal(b, '2');
+        }
+      }
+      this.registerModifierClass(
+        'songbird',
+        Modifier.modifier(SongbirdModifier)
+      );
+      await render(hbs`
+        {{#if this.shouldRender}}
+          <h1 {{songbird "1" "2"}}>Hey</h1>
+        {{/if}}
+      `);
+      this.set('shouldRender', false);
+    });
+
+    test('named arguments are passed', async function(assert) {
+      this.shouldRender = true;
+      class SongbirdModifier extends Modifier {
+        willDestroyElement(_, { a, b }) {
+          assert.equal(a, '1');
+          assert.equal(b, '2');
+        }
+      }
+      this.registerModifierClass(
+        'songbird',
+        Modifier.modifier(SongbirdModifier)
+      );
+      await render(hbs`
+        {{#if this.shouldRender}}
+          <h1 {{songbird a="1" b="2"}}>Hey</h1>
+        {{/if}}
+      `);
+      this.set('shouldRender', false);
+    });
+  });
+  
+  module('willDestroyElement without calling Modifier.modifier', function() {
     test('it has DOM element on this.element', async function(assert) {
       this.shouldRender = true;
       this.registerModifierClass(
@@ -194,53 +382,109 @@ module('Integration | Modifier Manager | oo modifier (native)', function(hooks) 
     });
   });
 
-  test('has correct lifecycle hooks ordering', async function(assert) {
-    let callstack = [];
-    this.value = 0;
-    this.shouldRender = true;
-    this.registerModifierClass(
-      'songbird',
+  module('Lifecycle and dependency with calling deprecated Modifier.modifier', function() {
+    test('has correct lifecycle hooks ordering', async function(assert) {
+      let callstack = [];
+      this.value = 0;
+      this.shouldRender = true;
       class SongbirdModifier extends Modifier {
         didInsertElement() { callstack.push('didInsertElement'); }
         didReceiveArguments() { callstack.push('didReceiveArguments'); }
         didUpdateArguments() { callstack.push('didUpdateArguments'); }
         willDestroyElement() { callstack.push('willDestroyElement'); }
       }
-    );
-    await render(hbs`
+      this.registerModifierClass(
+        'songbird',
+        Modifier.modifier(SongbirdModifier)
+      );
+      await render(hbs`
       {{#if this.shouldRender}}
         <h1 {{songbird this.value}}>Hey</h1>
       {{/if}}
     `);
-    this.set('value', 1);
-    await settled();
-    this.set('shouldRender', false);
-    await settled();
-    assert.deepEqual(callstack, [
-      'didInsertElement',
-      'didReceiveArguments',
-      'didReceiveArguments',
-      'didUpdateArguments',
-      'willDestroyElement'
-    ]);
-  });
+      this.set('value', 1);
+      await settled();
+      this.set('shouldRender', false);
+      await settled();
+      assert.deepEqual(callstack, [
+        'didInsertElement',
+        'didReceiveArguments',
+        'didReceiveArguments',
+        'didUpdateArguments',
+        'willDestroyElement'
+      ]);
+    });
 
-  test('can participate in ember dependency injection', async function(assert) {
-    this.owner.register(
-      'service:test-service',
-      class TestService extends Service {
-        value = 'test-service-value'
-      }
-    );
-    this.registerModifierClass(
-      'songbird',
+    test('can participate in ember dependency injection', async function(assert) {
+      this.owner.register(
+        'service:test-service',
+        class TestService extends Service {
+          value = 'test-service-value'
+        }
+      );
       class SongbirdModifier extends Modifier {
         @service testService
         didInsertElement() {
           assert.equal(this.testService.value, 'test-service-value');
         }
       }
-    );
-    await render(hbs`<h1 {{songbird}}>Hello</h1>`);
+      this.registerModifierClass(
+        'songbird',
+        Modifier.modifier(SongbirdModifier)
+      );
+      await render(hbs`<h1 {{songbird}}>Hello</h1>`);
+    });
+  });
+
+  module('Lifecycle and dependency without calling Modifier.modifier', function() {
+    test('has correct lifecycle hooks ordering', async function(assert) {
+      let callstack = [];
+      this.value = 0;
+      this.shouldRender = true;
+      this.registerModifierClass(
+        'songbird',
+        class SongbirdModifier extends Modifier {
+          didInsertElement() { callstack.push('didInsertElement'); }
+          didReceiveArguments() { callstack.push('didReceiveArguments'); }
+          didUpdateArguments() { callstack.push('didUpdateArguments'); }
+          willDestroyElement() { callstack.push('willDestroyElement'); }
+        }
+      );
+      await render(hbs`
+      {{#if this.shouldRender}}
+        <h1 {{songbird this.value}}>Hey</h1>
+      {{/if}}
+    `);
+      this.set('value', 1);
+      await settled();
+      this.set('shouldRender', false);
+      await settled();
+      assert.deepEqual(callstack, [
+        'didInsertElement',
+        'didReceiveArguments',
+        'didReceiveArguments',
+        'didUpdateArguments',
+        'willDestroyElement'
+      ]);
+    });
+
+    test('can participate in ember dependency injection', async function(assert) {
+      this.owner.register(
+        'service:test-service',
+        class TestService extends Service {
+          value = 'test-service-value'
+        }
+      );
+      this.registerModifierClass(
+        'songbird',
+        class SongbirdModifier extends Modifier {
+          @service testService
+          didInsertElement() {
+            assert.equal(this.testService.value, 'test-service-value');
+          }
+        }
+      );
+      await render(hbs`<h1 {{songbird}}>Hello</h1>`);
+    });
   });
 });


### PR DESCRIPTION
It was previously deemed necessary to call Modifier.modifier on the exported modifier class.  We can remove this requirement based on the input of @chancancode in #7.  This commit implements the behaviour as we understood it from this issue.

The deprecation message indicates version 1.0.0 will drop support for calling Modifier.modifier, this has not been discussed and is subject to change.

The examples of the README have been updated to remove the deprecated Modifier.modifier call.

The tests have been duplicated to contain both the calls with Modifier.modifier as well as those without.  The tests have been updated mechanically with Emacs Macro's rather than being smart about them to keep them obvious.